### PR TITLE
詳細画面でブーストされたトゥートのカスタム絵文字が表示されないのを修正

### DIFF
--- a/Sources/iOS/App/CustomViews/Post/PostDetail/MastodonPostDetailContentViewController.swift
+++ b/Sources/iOS/App/CustomViews/Post/PostDetail/MastodonPostDetailContentViewController.swift
@@ -170,7 +170,7 @@ class MastodonPostDetailContentViewController: UIViewController, Instantiatable,
         }
         textView.attributedText = post.status.parseText2HTMLNew(attributes: attrs)?.emojify(asyncLoadProgressHandler: { [weak textView] in
             textView?.setNeedsDisplay()
-        }, emojifyProtocol: input)
+        }, emojifyProtocol: post)
         
         attachedMediaListViewController.input(post)
     }


### PR DESCRIPTION
BTした側のオブジェクトが参照されていたので、カスタム絵文字が無になっていました。