### PR TITLE
プロフィール補足情報の表示サポート

### DIFF
--- a/Sources/Core/Mastodon/API/MastodonAccount.swift
+++ b/Sources/Core/Mastodon/API/MastodonAccount.swift
@@ -37,6 +37,7 @@ public struct MastodonAccount: Codable, EmojifyProtocol, MastodonEndpointRespons
     public let url: String
     public let avatarUrl: String
     public let headerUrl: String
+    public let fields: [MastodonAccountField]?
 
     public let acct: String
     let moved: IndirectBox<MastodonAccount>?
@@ -61,6 +62,7 @@ public struct MastodonAccount: Codable, EmojifyProtocol, MastodonEndpointRespons
         case url
         case avatarUrl = "avatar_static"
         case headerUrl = "header_static"
+        case fields
 
         case acct
         case moved
@@ -99,6 +101,17 @@ struct MastodonFollowList {
     var prev: MastodonID?
     var next: MastodonID?
     
+}
+
+public struct MastodonAccountField: Codable {
+    public let name: String
+    public let value: String
+    public let verifiedAt: Date?
+    enum CodingKeys: String, CodingKey {
+        case name
+        case value
+        case verifiedAt = "verified_at"
+    }
 }
 
 extension MastodonEndpoint {

--- a/Sources/iOS/App/CustomViews/UserProfile/UserProfileFieldViewController.swift
+++ b/Sources/iOS/App/CustomViews/UserProfile/UserProfileFieldViewController.swift
@@ -35,6 +35,8 @@ class UserProfileFieldViewController: UIViewController, Instantiatable, Injectab
 
     let nameLabel = UILabel() ※ { v in
         v.font = .systemFont(ofSize: UIFont.systemFontSize)
+        v.setContentHuggingPriority(.fittingSizeLevel, for: .horizontal)
+        v.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     }
     let valueLabel = UITextView() ※ { v in
         v.font = .systemFont(ofSize: UIFont.systemFontSize)
@@ -44,6 +46,11 @@ class UserProfileFieldViewController: UIViewController, Instantiatable, Injectab
         v.textContainerInset = .zero
         v.textContainer.lineFragmentPadding = 0
     }
+    let verifiedAtLabel = UILabel() ※ { v in
+        v.font = .boldSystemFont(ofSize: UIFont.systemFontSize)
+        v.textColor = v.tintColor
+    }
+    let verifiedIcon = UIImageView(image: UIImage(systemName: "checkmark.circle.fill"))
 
     required init(with input: Input, environment: MastodonUserToken) {
         self.input = input
@@ -57,14 +64,29 @@ class UserProfileFieldViewController: UIViewController, Instantiatable, Injectab
 
     override func loadView() {
         let view = UIView()
-        let stackView = UIStackView(arrangedSubviews: [
+        let verifiedStackView = UIStackView(arrangedSubviews: [
+            verifiedAtLabel,
+            verifiedIcon,
+        ]) ※ {
+            $0.axis = .horizontal
+            $0.spacing = 4
+        }
+        let nameStackView = UIStackView(arrangedSubviews: [
             nameLabel,
+            verifiedStackView,
+        ]) ※ {
+            $0.axis = .horizontal
+            $0.spacing = 4
+        }
+        let mainStackView = UIStackView(arrangedSubviews: [
+            nameStackView,
             valueLabel,
-        ])
-        stackView.axis = .vertical
-        stackView.spacing = 4
-        view.addSubview(stackView)
-        stackView.snp.makeConstraints { make in
+        ]) ※ {
+            $0.axis = .vertical
+            $0.spacing = 4
+        }
+        view.addSubview(mainStackView)
+        mainStackView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(16)
             make.top.bottom.equalToSuperview().inset(8)
         }
@@ -103,6 +125,15 @@ class UserProfileFieldViewController: UIViewController, Instantiatable, Injectab
             self.valueLabel.attributedText = value
         } else {
             self.valueLabel.text = input.field.value.toPlainText()
+        }
+
+        if let verifiedAt = input.field.verifiedAt {
+            self.verifiedIcon.isHidden = false
+            self.verifiedAtLabel.isHidden = false
+            self.verifiedAtLabel.text = DateUtils.stringFromDate(verifiedAt, format: "yyyy/MM/dd")
+        } else {
+            self.verifiedIcon.isHidden = true
+            self.verifiedAtLabel.isHidden = true
         }
     }
 

--- a/Sources/iOS/App/CustomViews/UserProfile/UserProfileFieldViewController.swift
+++ b/Sources/iOS/App/CustomViews/UserProfile/UserProfileFieldViewController.swift
@@ -38,6 +38,7 @@ class UserProfileFieldViewController: UIViewController, Instantiatable, Injectab
     }
     let valueLabel = UITextView() ※ { v in
         v.font = .systemFont(ofSize: UIFont.systemFontSize)
+        v.backgroundColor = .clear
         v.isScrollEnabled = false
         v.isEditable = false
         v.textContainerInset = .zero

--- a/Sources/iOS/App/CustomViews/UserProfile/UserProfileFieldViewController.swift
+++ b/Sources/iOS/App/CustomViews/UserProfile/UserProfileFieldViewController.swift
@@ -38,7 +38,7 @@ class UserProfileFieldViewController: UIViewController, Instantiatable, Injectab
         v.setContentHuggingPriority(.fittingSizeLevel, for: .horizontal)
         v.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     }
-    let valueLabel = UITextView() ※ { v in
+    let valueTextView = UITextView() ※ { v in
         v.font = .systemFont(ofSize: UIFont.systemFontSize)
         v.backgroundColor = .clear
         v.isScrollEnabled = false
@@ -80,7 +80,7 @@ class UserProfileFieldViewController: UIViewController, Instantiatable, Injectab
         }
         let mainStackView = UIStackView(arrangedSubviews: [
             nameStackView,
-            valueLabel,
+            valueTextView,
         ]) ※ {
             $0.axis = .vertical
             $0.spacing = 4
@@ -95,7 +95,7 @@ class UserProfileFieldViewController: UIViewController, Instantiatable, Injectab
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        valueLabel.delegate = self
+        valueTextView.delegate = self
         input(input)
     }
 
@@ -118,13 +118,13 @@ class UserProfileFieldViewController: UIViewController, Instantiatable, Injectab
             .font: UIFont.systemFont(ofSize: UIFont.systemFontSize),
             .foregroundColor: UIColor.label,
         ], asyncLoadProgressHandler: {
-            self.valueLabel.setNeedsDisplay()
+            self.valueTextView.setNeedsDisplay()
         })?.emojify(asyncLoadProgressHandler: {
-            self.valueLabel.setNeedsDisplay()
+            self.valueTextView.setNeedsDisplay()
         }, emojifyProtocol: input.account) {
-            self.valueLabel.attributedText = value
+            self.valueTextView.attributedText = value
         } else {
-            self.valueLabel.text = input.field.value.toPlainText()
+            self.valueTextView.text = input.field.value.toPlainText()
         }
 
         if let verifiedAt = input.field.verifiedAt {

--- a/Sources/iOS/App/CustomViews/UserProfile/UserProfileFieldViewController.swift
+++ b/Sources/iOS/App/CustomViews/UserProfile/UserProfileFieldViewController.swift
@@ -1,0 +1,145 @@
+//
+//  UserProfileFieldViewController.swift
+//
+//  iMast https://github.com/cinderella-project/iMast
+//
+//  Created by shibafu on 2021/08/15.
+//
+//  ------------------------------------------------------------------------
+//
+//  Copyright 2017-2021 rinsuki and other contributors.
+// 
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0
+// 
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import UIKit
+import SafariServices
+import iMastiOSCore
+import Ikemen
+import Mew
+
+class UserProfileFieldViewController: UIViewController, Instantiatable, Injectable, UITextViewDelegate {
+    typealias Input = (account: MastodonAccount, field: MastodonAccountField)
+    typealias Environment = MastodonUserToken
+    var input: Input
+    var environment: Environment
+
+    let nameLabel = UILabel() ※ { v in
+        v.font = .systemFont(ofSize: UIFont.systemFontSize)
+    }
+    let valueLabel = UITextView() ※ { v in
+        v.font = .systemFont(ofSize: UIFont.systemFontSize)
+        v.isScrollEnabled = false
+        v.isEditable = false
+        v.textContainerInset = .zero
+        v.textContainer.lineFragmentPadding = 0
+    }
+
+    required init(with input: Input, environment: MastodonUserToken) {
+        self.input = input
+        self.environment = environment
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        let view = UIView()
+        let stackView = UIStackView(arrangedSubviews: [
+            nameLabel,
+            valueLabel,
+        ])
+        stackView.axis = .vertical
+        stackView.spacing = 4
+        view.addSubview(stackView)
+        stackView.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview().inset(16)
+            make.top.bottom.equalToSuperview().inset(8)
+        }
+        self.view = view
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        valueLabel.delegate = self
+        input(input)
+    }
+
+    func input(_ input: Input) {
+        self.input = input
+        if let name = input.field.name.parseText2HTMLNew(attributes: [
+            .font: UIFont.systemFont(ofSize: UIFont.systemFontSize),
+            .foregroundColor: UIColor.label,
+        ], asyncLoadProgressHandler: {
+            self.nameLabel.setNeedsDisplay()
+        })?.emojify(asyncLoadProgressHandler: {
+            self.nameLabel.setNeedsDisplay()
+        }, emojifyProtocol: input.account) {
+            self.nameLabel.attributedText = name
+        } else {
+            self.nameLabel.text = input.field.name.toPlainText()
+        }
+
+        if let value = input.field.value.parseText2HTMLNew(attributes: [
+            .font: UIFont.systemFont(ofSize: UIFont.systemFontSize),
+            .foregroundColor: UIColor.label,
+        ], asyncLoadProgressHandler: {
+            self.valueLabel.setNeedsDisplay()
+        })?.emojify(asyncLoadProgressHandler: {
+            self.valueLabel.setNeedsDisplay()
+        }, emojifyProtocol: input.account) {
+            self.valueLabel.attributedText = value
+        } else {
+            self.valueLabel.text = input.field.value.toPlainText()
+        }
+    }
+
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        let string = (textView.attributedText.string as NSString).substring(with: characterRange)
+        if string.hasPrefix("@") {
+            let alert = UIAlertController(title: "ユーザー検索中", message: "\(URL.absoluteString)\n\nしばらくお待ちください", preferredStyle: .alert)
+            var canceled = false
+            alert.addAction(UIAlertAction(title: "キャンセル", style: .cancel, handler: { _ in
+                canceled = true
+                alert.dismiss(animated: true, completion: nil)
+            }))
+            alert.addAction(UIAlertAction(title: "強制的にSafariで開く", style: .default, handler: { [weak self] _ in
+                canceled = true
+                alert.dismiss(animated: true, completion: nil)
+                let safari = SFSafariViewController(url: URL)
+                self?.present(safari, animated: true, completion: nil)
+            }))
+            environment.search(q: URL.absoluteString, resolve: true).then { [weak self] result in
+                guard let strongSelf = self else { return }
+                if canceled { return }
+                alert.dismiss(animated: true) {
+                    if let account = result.accounts.first {
+                        let newVC = UserProfileTopViewController.instantiate(account, environment: strongSelf.environment)
+                        strongSelf.navigationController?.pushViewController(newVC, animated: true)
+                    } else {
+                        let safari = SFSafariViewController(url: URL)
+                        strongSelf.present(safari, animated: true, completion: nil)
+                    }
+                }
+            }.catch { error in
+                alert.dismiss(animated: true, completion: nil)
+            }
+            self.present(alert, animated: true, completion: nil)
+            return false
+        }
+        let safari = SFSafariViewController(url: URL)
+        self.present(safari, animated: true, completion: nil)
+        return false
+    }
+}

--- a/Sources/iOS/App/CustomViews/UserProfile/UserProfileFieldViewController.swift
+++ b/Sources/iOS/App/CustomViews/UserProfile/UserProfileFieldViewController.swift
@@ -130,7 +130,10 @@ class UserProfileFieldViewController: UIViewController, Instantiatable, Injectab
         if let verifiedAt = input.field.verifiedAt {
             self.verifiedIcon.isHidden = false
             self.verifiedAtLabel.isHidden = false
-            self.verifiedAtLabel.text = DateUtils.stringFromDate(verifiedAt, format: "yyyy/MM/dd")
+            let formatter = DateFormatter()
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .none
+            self.verifiedAtLabel.text = formatter.string(from: verifiedAt)
         } else {
             self.verifiedIcon.isHidden = true
             self.verifiedAtLabel.isHidden = true

--- a/Sources/iOS/App/CustomViews/UserProfile/UserProfileFieldViewController.swift
+++ b/Sources/iOS/App/CustomViews/UserProfile/UserProfileFieldViewController.swift
@@ -48,9 +48,11 @@ class UserProfileFieldViewController: UIViewController, Instantiatable, Injectab
     }
     let verifiedAtLabel = UILabel() ※ { v in
         v.font = .boldSystemFont(ofSize: UIFont.systemFontSize)
-        v.textColor = v.tintColor
+        v.textColor = .systemGreen
     }
-    let verifiedIcon = UIImageView(image: UIImage(systemName: "checkmark.circle.fill"))
+    let verifiedIcon = UIImageView(image: UIImage(systemName: "checkmark.circle.fill")) ※ { v in
+        v.tintColor = .systemGreen
+    }
 
     required init(with input: Input, environment: MastodonUserToken) {
         self.input = input

--- a/Sources/iOS/App/CustomViews/UserProfile/UserProfileTopViewController.swift
+++ b/Sources/iOS/App/CustomViews/UserProfile/UserProfileTopViewController.swift
@@ -174,7 +174,7 @@ class UserProfileTopViewController: StableTableViewController, Instantiatable, I
             cells[0].append(cell)
         }
         if let fields = input.fields {
-            fields.indices.forEach { index in
+            for index in fields.indices {
                 let cell = UITableViewCell()
                 cell.accessibilityIdentifier = "fieldCell"
                 cell.tag = index

--- a/Sources/iOS/App/CustomViews/UserProfile/UserProfileTopViewController.swift
+++ b/Sources/iOS/App/CustomViews/UserProfile/UserProfileTopViewController.swift
@@ -73,6 +73,7 @@ class UserProfileTopViewController: StableTableViewController, Instantiatable, I
        
         self.input(input)
         TableViewCell<UserProfileBioViewController>.register(to: tableView)
+        TableViewCell<UserProfileFieldViewController>.register(to: tableView)
     }
     
     @objc func reload() {
@@ -171,6 +172,14 @@ class UserProfileTopViewController: StableTableViewController, Instantiatable, I
             let cell = UITableViewCell()
             cell.accessibilityIdentifier = "bioCell"
             cells[0].append(cell)
+        }
+        if let fields = input.fields {
+            fields.indices.forEach { index in
+                let cell = UITableViewCell()
+                cell.accessibilityIdentifier = "fieldCell"
+                cell.tag = index
+                cells[0].append(cell)
+            }
         }
         if input.acct.contains("@") {
             cells[0].append(checkLatestProfileCell)
@@ -338,6 +347,15 @@ class UserProfileTopViewController: StableTableViewController, Instantiatable, I
                 from: tableView,
                 for: indexPath,
                 input: input,
+                parentViewController: self
+            )
+            cell.separatorInset = .zero
+            return cell
+        } else if cell.accessibilityIdentifier == "fieldCell" {
+            let cell = TableViewCell<UserProfileFieldViewController>.dequeued(
+                from: tableView,
+                for: indexPath,
+                input: (account: input, field: input.fields![cell.tag]),
                 parentViewController: self
             )
             cell.separatorInset = .zero

--- a/iMast.xcodeproj/project.pbxproj
+++ b/iMast.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		2AF352301EAB9C5600777C2E /* iMastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF3522F1EAB9C5600777C2E /* iMastTests.swift */; };
 		2AF3523B1EAB9C5600777C2E /* iMastUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF3523A1EAB9C5600777C2E /* iMastUITests.swift */; };
 		3CB0034D20C8D2DE04A5A969 /* Pods_iMastShared_Mac_iMast_Mac__App_Store_.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E4C871ACF3804089BD53C1A /* Pods_iMastShared_Mac_iMast_Mac__App_Store_.framework */; };
+		5D337B0226C952F600258CD1 /* UserProfileFieldViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D337B0126C952F600258CD1 /* UserProfileFieldViewController.swift */; };
 		617DCFFE4FE3CD56EDE14AD4 /* Pods_iMastShared_Mac_iMastMacCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EEED81AAD927A30AFB818324 /* Pods_iMastShared_Mac_iMastMacCore.framework */; };
 		78E0877ECED7B80513CC23A5 /* Pods_iMastShared_iOS_iMastNotifyService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE46AB9BC10111AED90813E9 /* Pods_iMastShared_iOS_iMastNotifyService.framework */; };
 		904584C585DF8DF528E745A9 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
@@ -618,6 +619,7 @@
 		4F2AB9461E461D9AAE0C3D54 /* Pods-iMastShared-iOS-iMastIntents.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iMastShared-iOS-iMastIntents.release.xcconfig"; path = "Pods/Target Support Files/Pods-iMastShared-iOS-iMastIntents/Pods-iMastShared-iOS-iMastIntents.release.xcconfig"; sourceTree = "<group>"; };
 		5381BC0B6D32B2431F388D80 /* Pods-iMastShared-iOS-iMast-iMastUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iMastShared-iOS-iMast-iMastUITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-iMastShared-iOS-iMast-iMastUITests/Pods-iMastShared-iOS-iMast-iMastUITests.release.xcconfig"; sourceTree = "<group>"; };
 		599E62B81E7F4F5E82780FF1 /* Pods-iMastShared-iOS-iMast iOS-iMastUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iMastShared-iOS-iMast iOS-iMastUITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-iMastShared-iOS-iMast iOS-iMastUITests/Pods-iMastShared-iOS-iMast iOS-iMastUITests.release.xcconfig"; sourceTree = "<group>"; };
+		5D337B0126C952F600258CD1 /* UserProfileFieldViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileFieldViewController.swift; sourceTree = "<group>"; };
 		5E4C871ACF3804089BD53C1A /* Pods_iMastShared_Mac_iMast_Mac__App_Store_.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iMastShared_Mac_iMast_Mac__App_Store_.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		687BB408B5B20F62EE7044D9 /* Pods-iMastIntents.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iMastIntents.release.xcconfig"; path = "Pods/Target Support Files/Pods-iMastIntents/Pods-iMastIntents.release.xcconfig"; sourceTree = "<group>"; };
 		694662BBDCFC9D77A4DFC768 /* Pods-iMastShare.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iMastShare.release.xcconfig"; path = "Pods/Target Support Files/Pods-iMastShare/Pods-iMastShare.release.xcconfig"; sourceTree = "<group>"; };
@@ -1693,6 +1695,7 @@
 				CE6977861F0EE8A600C1B234 /* UserProfileTopViewController.swift */,
 				CE54BC7520E041A50034B63E /* UserProfileInfoTableViewCell.swift */,
 				CE54BC7920E0546E0034B63E /* UserProfileBioViewController.swift */,
+				5D337B0126C952F600258CD1 /* UserProfileFieldViewController.swift */,
 			);
 			path = UserProfile;
 			sourceTree = "<group>";
@@ -3431,6 +3434,7 @@
 				CEF15AFF1FF74F9400836A4C /* FollowRequestsListTableViewController.swift in Sources */,
 				CE97DB6022D4B9D900D2BDC6 /* MastodonPostWrapperViewController.swift in Sources */,
 				CE71AF4E224221090054A008 /* NSAttributedString+emojify.swift in Sources */,
+				5D337B0226C952F600258CD1 /* UserProfileFieldViewController.swift in Sources */,
 				CE5099BB21BE60A700C09C16 /* CreateSiriShortcutsViewController.swift in Sources */,
 				CEA787D62696EFAB002C9A5C /* Hydra.Promise+wrapper.swift in Sources */,
 				CE7DBED021843141008727D4 /* SearchViewController.swift in Sources */,


### PR DESCRIPTION
refs #175 

このPRでは、WebUI上でプロフィール補足情報と呼ばれている `account.fields` の表示を追加します。

SwiftおよびUIKitを使うのには慣れておらず見様見真似で書いたので、間違っている所などあったら教えてください。

## 詰めきれていない所

* verified_at が付いている項目に何か表示するべきか
  * WebUIでは ✅ が付き、セルの背景が緑色になる。nameかvalueいずれかの先頭に ✅ を置いてみるのは考えたが、やっていない。何か良案があれば。

## Screenshot

<img width="564" alt="スクリーンショット 2021-08-16 22 53 12" src="https://user-images.githubusercontent.com/1352154/129574759-c1a05b18-e12a-45f5-baf6-6f44873d3e25.png">
